### PR TITLE
This adds the capability to start a VM in foreground

### DIFF
--- a/pkg/network/bridge.go
+++ b/pkg/network/bridge.go
@@ -120,30 +120,3 @@ func (e *Environment) BridgeUp() error {
 	}
 	return netlink.LinkSetUp(e.BridgeLink)
 }
-
-// //CreateBridge will create a new Layer 2 bridge
-// func CreateBridge() error {
-// 	// Create a new network bridge
-// 	la := netlink.NewLinkAttrs()
-// 	la.Name = "plunder"
-
-// 	mybridge := &netlink.Bridge{LinkAttrs: la}
-// 	err := netlink.LinkAdd(mybridge)
-// 	if err != nil {
-// 		fmt.Printf("could not add %s: %v\n", la.Name, err)
-// 	}
-
-// 	tap := &netlink.Tuntap{LinkAttrs: netlink.LinkAttrs{Name: "plunderVM"}, Mode: netlink.TUNTAP_MODE_TAP}
-// 	err = netlink.LinkAdd(tap)
-// 	if err != nil {
-// 		fmt.Printf("could not add %s: %v\n", la.Name, err)
-// 	}
-
-// 	netlink.LinkSetMaster(tap, mybridge)
-// 	addr, _ := netlink.ParseAddr("192.168.1.1/24")
-// 	netlink.AddrAdd(mybridge, addr)
-
-// 	netlink.LinkSetUp(mybridge)
-
-// 	return nil
-// }

--- a/pkg/network/tap.go
+++ b/pkg/network/tap.go
@@ -38,13 +38,13 @@ func (e *Environment) DeleteTap(tapName string) error {
 	// Find Tap
 	tapLink, err := netlink.LinkByName(tapName)
 	if err != nil {
-		return err
+		return fmt.Errorf("Could not delete %s: %v", tapName, err)
 	}
 
 	// Remove Tap device
 	err = netlink.LinkDel(tapLink)
 	if err != nil {
-		return fmt.Errorf("Could not delete %s: %v", e.BridgeName, err)
+		return fmt.Errorf("Could not delete %s: %v", tapName, err)
 	}
 	return nil
 

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -49,7 +49,7 @@ func ExampleConfig() string {
 	cfg := Environment{}
 	cfg.BridgeAddress = "192.168.1.1/24"
 	cfg.BridgeName = "plunder"
-	cfg.NicPrefix = "plunderVM"
+	cfg.NicPrefix = "plndrVM"
 	cfg.NicMacPrefix = "c0:ff:ee:"
 
 	b, _ := yaml.Marshal(cfg)


### PR DESCRIPTION
New:
- `--foreground` flag for `vm start`

Fixes:
- Fixes to Tap device name (> 15 can't be deleted)
- Fixes to error reporting from tap deletion