### PR TITLE
Additional features

### DIFF
--- a/cmd/chest.go
+++ b/cmd/chest.go
@@ -5,14 +5,9 @@ import (
 	"os"
 
 	"github.com/plunder-app/chest/pkg/network"
-	"github.com/plunder-app/chest/pkg/vmm"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
-
-var vmUUID string
-var foreground bool
 
 // Release - this struct contains the release information populated when building chest
 var Release struct {
@@ -21,13 +16,6 @@ var Release struct {
 }
 
 func init() {
-
-	chestVM.PersistentFlags().StringVar(&vmUUID, "id", "000000", "The UUID for a virtual machine")
-	chestVMStart.Flags().BoolVarP(&foreground, "foreground", "f", false, "The UUID for a virtual machine")
-
-	// Add subcommands
-	chestVM.AddCommand(chestVMStart)
-	chestVM.AddCommand(chestVMStop)
 
 	// Main function commands
 	chestCmd.AddCommand(chestExample)
@@ -67,79 +55,6 @@ var chestNetwork = &cobra.Command{
 	Short: "Create the networking",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
-	},
-}
-
-var chestVM = &cobra.Command{
-	Use:   "vm",
-	Short: "Create the networking",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Chest VM configuration\n")
-		cmd.Help()
-	},
-}
-
-var chestVMStart = &cobra.Command{
-	Use:   "start",
-	Short: "Start a virtual Machine",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Chest VM configuration\n")
-		cfg, err := network.OpenFile(configPath)
-		if err != nil {
-			log.Fatal(err)
-		}
-		if vmUUID == "000000" {
-			// Generate VM UUID
-			b, err := vmm.GenVMUUID()
-			if err != nil {
-				log.Fatal(err)
-			}
-			vmUUID = fmt.Sprintf("%02x%02x%02x", b[0], b[1], b[2])
-		}
-
-		vmInterface := fmt.Sprintf("%s-%s", cfg.NicPrefix, vmUUID)
-		if len(vmInterface) > 15 {
-			log.Fatalf("The interface name [%s] is too long for the interface standard, shorten the nicPrefix", vmInterface)
-		}
-		// Create Tap Device (and add to bridge)
-		cfg.CreateTap(vmInterface)
-
-		// Generate MAC address using UUID and Mac prefix
-		mac := vmm.GenVMMac(cfg.NicMacPrefix, vmUUID)
-
-		// Create Disk
-		vmm.CreateDisk(vmUUID, "4G")
-
-		// Start Virtual Machine
-		vmm.Start(mac, vmUUID, cfg.NicPrefix, foreground)
-
-		// If this is ran in the foreground then we will want to tidy up the created interface
-		if foreground {
-			log.Infof("Deleting interface [%s]", vmInterface)
-			err = cfg.DeleteTap(vmInterface)
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
-	},
-}
-
-var chestVMStop = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop a virtual Machine",
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := network.OpenFile(configPath)
-		if err != nil {
-			log.Fatal(err)
-		}
-		// Stop Virtual Machine
-		vmm.Stop(vmUUID)
-		// Remove Networking configuration
-		err = cfg.DeleteTap(fmt.Sprintf("%s-%s", cfg.NicPrefix, vmUUID))
-		if err != nil {
-			log.Fatal(err)
-		}
-		// TODO - Delete disk?
 	},
 }
 

--- a/cmd/chestVMM.go
+++ b/cmd/chestVMM.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/plunder-app/chest/pkg/network"
+	"github.com/plunder-app/chest/pkg/vmm"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var vmUUID string
+var foreground, vnc, disk bool
+
+func init() {
+
+	chestVM.PersistentFlags().StringVar(&vmUUID, "id", "000000", "The UUID for a virtual machine")
+	chestVMStart.Flags().BoolVarP(&foreground, "foreground", "f", false, "The UUID for a virtual machine")
+	chestVMStart.Flags().BoolVarP(&vnc, "vnc", "v", false, "Enable VNC")
+	chestVMStop.Flags().BoolVarP(&disk, "disk", "d", false, "Delete Disk")
+
+	// Add subcommands
+	chestVM.AddCommand(chestVMStart)
+	chestVM.AddCommand(chestVMStop)
+}
+
+var chestVM = &cobra.Command{
+	Use:   "vm",
+	Short: "Create the networking",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Chest VM configuration\n")
+		cmd.Help()
+	},
+}
+
+var chestVMStart = &cobra.Command{
+	Use:   "start",
+	Short: "Start a virtual Machine",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Chest VM configuration\n")
+		cfg, err := network.OpenFile(configPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if vmUUID == "000000" {
+			// Generate VM UUID
+			b, err := vmm.GenVMUUID()
+			if err != nil {
+				log.Fatal(err)
+			}
+			vmUUID = fmt.Sprintf("%02x%02x%02x", b[0], b[1], b[2])
+		}
+
+		vmInterface := fmt.Sprintf("%s-%s", cfg.NicPrefix, vmUUID)
+		if len(vmInterface) > 15 {
+			log.Fatalf("The interface name [%s] is too long for the interface standard, shorten the nicPrefix", vmInterface)
+		}
+		// Create Tap Device (and add to bridge)
+		cfg.CreateTap(vmInterface)
+
+		// Generate MAC address using UUID and Mac prefix
+		mac := vmm.GenVMMac(cfg.NicMacPrefix, vmUUID)
+
+		// Create Disk
+		vmm.CreateDisk(vmUUID, "4G")
+
+		// Start Virtual Machine
+		vmm.Start(mac, vmUUID, cfg.NicPrefix, foreground, vnc)
+
+		// If this is ran in the foreground then we will want to tidy up the created interface
+		if foreground {
+			log.Infof("Deleting interface [%s]", vmInterface)
+			err = cfg.DeleteTap(vmInterface)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+	},
+}
+
+var chestVMStop = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop a virtual Machine",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		cfg, err := network.OpenFile(configPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Stop Virtual Machine
+		err = vmm.Stop(vmUUID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Remove Networking configuration
+		err = cfg.DeleteTap(fmt.Sprintf("%s-%s", cfg.NicPrefix, vmUUID))
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Delete disk
+		if disk {
+			err = vmm.DeleteDisk(vmUUID)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+	},
+}

--- a/pkg/vmm/disk.go
+++ b/pkg/vmm/disk.go
@@ -21,3 +21,17 @@ func CreateDisk(uuid, size string) error {
 
 	return nil
 }
+
+// DeleteDisk - will create a disk for a qemu instance
+func DeleteDisk(uuid string) error {
+	imagePath := fmt.Sprintf("%s.qcow2", uuid)
+
+	// Check file stats
+	_, err := os.Stat(imagePath)
+	// If it doesn't exist then create it
+	if os.IsNotExist(err) {
+		return fmt.Errorf("The VM Disk [%s] does not exist", imagePath)
+	}
+
+	return os.Remove(imagePath)
+}


### PR DESCRIPTION
- `-vnc` flag will generate a random port that a VM will start on
- `-d` will remove the storage on `vm stop`
- `id` is now checked
- Fixes to error reporting